### PR TITLE
Fixed a serialization bug with dpop tokens in .net 7 and newer

### DIFF
--- a/ClientCredentialsKeypairs/AuthenticationService.cs
+++ b/ClientCredentialsKeypairs/AuthenticationService.cs
@@ -1,4 +1,5 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;

--- a/ClientCredentialsKeypairs/AuthenticationService.cs
+++ b/ClientCredentialsKeypairs/AuthenticationService.cs
@@ -1,5 +1,4 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
-using System.Linq;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
@@ -167,7 +166,7 @@ public class AuthenticationService : IAuthenticationService
             { JsonWebKeyParameterNames.N, jwk.N }
         }
         .Where(kvp => !string.IsNullOrEmpty(kvp.Value))
-        .ToDictionary();
+        .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
     }
 
     private string BuildClientAssertion(string audience, string clientId)

--- a/ClientCredentialsKeypairs/AuthenticationService.cs
+++ b/ClientCredentialsKeypairs/AuthenticationService.cs
@@ -148,15 +148,25 @@ public class AuthenticationService : IAuthenticationService
         var jwtSecurityToken = new JwtSecurityToken(claims: claims, signingCredentials: signingCredentials);
         jwtSecurityToken.Header.Remove("typ");
         jwtSecurityToken.Header.Add("typ", "dpop+jwt");
-        jwtSecurityToken.Header.Add("jwk", GetPublicJwk());
+        var jwkValue = GetPublicJwk();
+        jwtSecurityToken.Header.Add("jwk", jwkValue);
 
         var token = new JwtSecurityTokenHandler().WriteToken(jwtSecurityToken);
         return token;
     }
 
-    private JsonWebKey GetPublicJwk()
+    private Dictionary<string, string> GetPublicJwk()
     {
-        return new JsonWebKey(Config.PrivateKey).GetPublicKey();
+        var jwk = new JsonWebKey(Config.PrivateKey);
+        return new Dictionary<string, string>
+        {
+            { JsonWebKeyParameterNames.Alg, jwk.Alg },
+            { JsonWebKeyParameterNames.E, jwk.E },
+            { JsonWebKeyParameterNames.Kty, jwk.Kty },
+            { JsonWebKeyParameterNames.N, jwk.N }
+        }
+        .Where(kvp => !string.IsNullOrEmpty(kvp.Value))
+        .ToDictionary();
     }
 
     private string BuildClientAssertion(string audience, string clientId)

--- a/ClientCredentialsKeypairs/Fhi.ClientCredentialsKeypairs.csproj
+++ b/ClientCredentialsKeypairs/Fhi.ClientCredentialsKeypairs.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <authors>Folkehelseinstituttet (FHI)</authors>
     <Copyright>(c) 2022-2023 Folkehelseinstituttet (FHI)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
This PR fixes a bug which would only occur in services targeting .net 7 and later while creating DPoP tokens. The root cause was that during JSON serialization of the DPoP token, the JWT header representing the public key would throw an exception:
> "System.ArgumentException: 'IDX11025: Cannot serialize object of type: 'Microsoft.IdentityModel.Tokens.JsonWebKey' into property: 'jwk'.'".

This happened because in System.IdentityModel.Tokens.Jwt version 7 and later (this version was used in .net 7 and later), headers could no longer be of an arbitrary object that would be serialized into a JSON object but rather either a primitive, dictionary, or a `System.Text.Json.JsonElement`. The solution to this problem was to define a dictionary that represents the public key instead of sending in an object to the JWT header. 