### PR TITLE
Fixed a bug with services being incorrect registered in DI

### DIFF
--- a/ClientCredentialsKeypairs/Fhi.ClientCredentialsKeypairs.csproj
+++ b/ClientCredentialsKeypairs/Fhi.ClientCredentialsKeypairs.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <authors>Folkehelseinstituttet (FHI)</authors>
     <Copyright>(c) 2022-2023 Folkehelseinstituttet (FHI)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/ClientCredentialsKeypairs/ServiceExtensions.cs
+++ b/ClientCredentialsKeypairs/ServiceExtensions.cs
@@ -30,9 +30,7 @@ namespace Fhi.ClientCredentialsKeypairs
 
             services.AddSingleton<IAuthTokenStoreFactory, AuthTokenStoreFactory>();
             services.AddSingleton<ITokenStoreResolver, TokenStoreResolver>();
-            services.AddSingleton<IAuthTokenStore, AuthenticationStore>();
             services.AddSingleton(clientCredentialsConfiguration);
-            services.AddTransient<HttpAuthHandler>();
             return clientCredentialsConfiguration;
         }
 

--- a/Fhi.ClientCredentials.Refit/Fhi.ClientCredentials.Refit.csproj
+++ b/Fhi.ClientCredentials.Refit/Fhi.ClientCredentials.Refit.csproj
@@ -4,7 +4,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
-        <Version>1.2.0</Version>
+        <Version>1.2.1</Version>
         <id>Fhi.ClientCredentials.Refit</id>
         <authors>Folkehelseinstituttet (FHI)</authors>
         <Copyright>(c) 2023 Folkehelseinstituttet (FHI)</Copyright>


### PR DESCRIPTION
Starting a web service would throw the following exception:

```
Some services are not able to be constructed (Error while validating the service descriptor 'ServiceType: Fhi.ClientCredentialsKeypairs.IAuthTokenStore Lifetime: Singleton ImplementationType: Fhi.ClientCredentialsKeypairs.AuthenticationStore': Unable to resolve service for type 'Fhi.ClientCredentialsKeypairs.IAuthenticationService' while attempting to activate 'Fhi.ClientCredentialsKeypairs.AuthenticationStore'.) (Error while validating the service descriptor 'ServiceType: Fhi.ClientCredentialsKeypairs.HttpAuthHandler Lifetime: Transient ImplementationType: Fhi.ClientCredentialsKeypairs.HttpAuthHandler': Unable to resolve service for type 'Fhi.ClientCredentialsKeypairs.IAuthenticationService' while attempting to activate 'Fhi.ClientCredentialsKeypairs.AuthenticationStore'.)
``` 