### PR TITLE
Fixed a bug with DPoP Htu claims having query params

### DIFF
--- a/ClientCredentialsKeypairs/HttpAuthHandler.cs
+++ b/ClientCredentialsKeypairs/HttpAuthHandler.cs
@@ -21,7 +21,9 @@ namespace Fhi.ClientCredentialsKeypairs
         {
             if (request.Options.All(x => x.Key != AnonymousOptionKey))
             {
-                var token = await _authTokenStore.GetToken(request.Method, request.RequestUri?.AbsoluteUri ?? "");
+                var requestUrl = request.RequestUri!.Scheme + "://" + request.RequestUri!.Authority +
+                                 request.RequestUri!.LocalPath;
+                var token = await _authTokenStore.GetToken(request.Method, requestUrl);
                 if (token != null)
                 {
                     if (token.TokenType.ToUpper() == DpopSchemeType.ToUpper())


### PR DESCRIPTION
From RFC9449:
> The htu claim matches the HTTP URI value for the HTTP request in which the JWT was received, ignoring any query and fragment parts.

We are creating tokens with HTU values that contains query parameters, which is not in accordance with RFC9449. This PR fixes this problem.