### PR TITLE
Remove cmd-files for copying nupkg-file

### DIFF
--- a/Fhi.ClientCredentials.sln
+++ b/Fhi.ClientCredentials.sln
@@ -6,7 +6,6 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{23941B0D-1155-48FC-BB25-1E2A842F35B7}"
 	ProjectSection(SolutionItems) = preProject
 		Building.md = Building.md
-		cplocal.cmd = cplocal.cmd
 		nuget.config = nuget.config
 		Readme.md = Readme.md
 	EndProjectSection

--- a/Fhi.ClientCredentialsKeypairs/cp.cmd
+++ b/Fhi.ClientCredentialsKeypairs/cp.cmd
@@ -1,1 +1,0 @@
-copy bin\debug\Fhi.ClientCredentialsKeypairs.%1.nupkg c:\nuget

--- a/cplocal.cmd
+++ b/cplocal.cmd
@@ -1,1 +1,0 @@
-copy ClientCredentialsKeypairs\bin\debug\*.nupkg c:\nuget


### PR DESCRIPTION
I can't see that these files are used anywhere.
Do we need them?